### PR TITLE
Remove the dependency on the windows cookbook.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,6 +7,6 @@ chef_version     '>= 13.0' if respond_to?(:chef_version)
 license          'Apache-2.0'
 description      'Installs/Configures 7-Zip'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.1.0'
+version          '4.0.0'
+chef_version     '>= 14.0'
 supports         'windows'
-depends          'windows'


### PR DESCRIPTION
The functionality of the windows cookbook was been merged into the Chef Client v14.