### PR TITLE
Update branches for ActionsHub 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,7 @@ name: ci
 "on":
   pull_request:
   push:
-    branches:
-      - master
+    branches: [master, main]
 
 jobs:
   delivery:
@@ -40,16 +39,17 @@ jobs:
     strategy:
       matrix:
         os:
-          - 'windows-latest'
+          - "windows-latest"
         suite:
-          - 'default'
+          - "default"
       fail-fast: false
-
     steps:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install Chef
         uses: actionshub/chef-install@main
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       - name: test-kitchen
         uses: actionshub/test-kitchen@main
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of seven_zip.
 
 ## Unreleased
 
+- [CI] Change ActionsHub actions to main
+- [CI] Change checkout action to v2
+- [CI] Change final step to an echo for faster final step
+
 ## 4.2.0 - *2021-06-07*
 
 - Add remove action to seven_zip_tool


### PR DESCRIPTION
# Description

- Update installer to allow the insecure action

## Issues Resolved

Chef install on Windows requires add-path and GitHub Actions no longer allows this by default

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
